### PR TITLE
Replace status message with status message number

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Note: this firmware works for multiple COZIR C02 sensors:
 - GC-0012
 
 It has not been tested on the GC-0010, but probably works with it as well.
+
+## Status Messages
+
+- "31": Failed to read from sensor

--- a/openag_gc0012.cpp
+++ b/openag_gc0012.cpp
@@ -53,7 +53,7 @@ void Gc0012::readData() {
   // Check for failure
   if (data_string[1] != 'Z') {
     status_level = ERROR;
-    status_msg = "Failed to read from sensor";
+    status_msg = "31";
   }
   else { // good reading
     status_level = OK;


### PR DESCRIPTION
This is a short-term fix for status message buffer overflow that simply reduces
the number of bits.